### PR TITLE
feat: add contributor regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,20 +36,24 @@ jobs:
           sentry_project_name: MyProject
           sentry_project_id: 1234
           grafana_dashboard_link: https://grafana.com/dashboards/XXXX
+          contributor_replace_regex: "--"
+          contributor_replace_char: "-"
 ```
 
 #### Inputs
 
-| Name                     | Required | Default | Description                                                                                           |
-| ------------------------ | -------- | ------- | ----------------------------------------------------------------------------------------------------- |
-| `github_token`           | yes      |         | Token to use to authorize label changes. Typically the GITHUB_TOKEN secret                            |
-| `repo`                   | no       |         | Repo name                                                                                             |
-| `slack_webhook_url`      | no       |         | Slack webhook URL to receive release notifications                                                    |
-| `jira_ticket_prefix`     | no       |         | Prefix for JIRA ticket references in PR titles (e.g. ABC)                                             |
-| `jira_instance_url`      | no       |         | URL for your JIRA instance to generate JIRA ticket links (e.g. https://your-jira-instance.com/browse) |
-| `sentry_project_name`    | no       |         | ID of the Sentry project for error tracking                                                           |
-| `sentry_project_name`    | no       |         | Name of the Sentry project for error tracking                                                         |
-| `grafana_dashboard_link` | no       |         | Link to the Grafana dashboard for monitoring                                                          |
+| Name                        | Required | Default | Description                                                                                               |
+| --------------------------- | -------- | ------- | --------------------------------------------------------------------------------------------------------- |
+| `github_token`              | yes      |         | Token to use to authorize label changes. Typically the GITHUB_TOKEN secret                                |
+| `repo`                      | no       |         | Name of the repo (e.g. owner/repo) if not the current one                                                 |
+| `contributor_replace_regex` | no       | "-"     | Regular expression (regex) pattern to identify characters in the `contributor` name that will be replaced |
+| `contributor_replace_char`  | no       | "."     | The character that will replace specific characters in the `contributor` name                             |
+| `slack_webhook_url`         | no       |         | Slack webhook URL to receive release notifications                                                        |
+| `jira_ticket_prefix`        | no       |         | Prefix for JIRA ticket references in PR titles (e.g. ABC)                                                 |
+| `jira_instance_url`         | no       |         | URL for your JIRA instance to generate JIRA ticket links (e.g. https://your-jira-instance.com/browse)     |
+| `sentry_project_name`       | no       |         | ID of the Sentry project for error tracking                                                               |
+| `sentry_project_name`       | no       |         | Name of the Sentry project for error tracking                                                             |
+| `grafana_dashboard_link`    | no       |         | Link to the Grafana dashboard for monitoring                                                              |
 
 
 ### Outputs

--- a/action.yml
+++ b/action.yml
@@ -12,6 +12,16 @@ inputs:
     description: Your GitHub token for authentication. It is used to get the repository information and generate the changelog.
     required: true
 
+  contributor_replace_regex:
+    description: An optional regular expression (regex) pattern to identify characters in the `contributor` name that will be replaced.
+    required: false
+    default: '-'
+
+  contributor_replace_char:
+    description: The character that will replace specific characters in the `contributor` name.
+    required: false
+    default: '.'
+
   repo:
     description: The repository for which the action should generate the changelog and post a release notification. If not provided, it defaults to the repository where the action is running.
     required: false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "publish-release-info-action",
-  "version": "0.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "publish-release-info-action",
-      "version": "0.0.0",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "publish-release-info-action",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "private": true,
   "description": "Sends release information to Slack and other communication platforms, keeping your team up-to-date with the latest releases",
   "main": "dist/index.js",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -39,6 +39,8 @@ describe('run function', () => {
       slackWebhookUrl: 'http://mock-webhook-url',
       jiraInstanceUrl: 'http://mock-jira-instance-url',
       jiraTicketPrefix: 'ABC',
+      contributorReplaceChar: '.',
+      contributorReplaceRegex: '-',
     })
 
     const getOwnerAndRepoMock = jest.spyOn(getOwnerAndRepoModule, 'getOwnerAndRepo')

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,9 @@ export async function run(): Promise<void> {
     const prListString = generatePRListString(
       contributorsCommitsWithTicketLinks,
       options.jiraTicketPrefix,
-      options.jiraInstanceUrl
+      options.jiraInstanceUrl,
+      options.contributorReplaceChar,
+      options.contributorReplaceRegex
     )
 
     const currentDate = new Date().toLocaleString('en-US', {

--- a/src/utils/__tests__/__mocks__/testData.ts
+++ b/src/utils/__tests__/__mocks__/testData.ts
@@ -61,4 +61,6 @@ export const MOCK_GET_INPUTS = {
   slackWebhookUrl: 'https://hooks.slack.com/services/123/456/789',
   jiraTicketPrefix: 'ABC',
   jiraInstanceUrl: 'https://jira.myProject.com',
+  contributorReplaceChar: '.',
+  contributorReplaceRegex: '-',
 }

--- a/src/utils/__tests__/generatePRListString.test.ts
+++ b/src/utils/__tests__/generatePRListString.test.ts
@@ -4,7 +4,7 @@ describe('generatePRListString', () => {
   it('should generate a proper PR list string', () => {
     const contributorsCommits = [
       {
-        contributor: 'contributor1',
+        contributor: 'people-one',
         prTitle: 'PR title 1 (ABC-123)',
         prUrl: 'https://github.com/owner/repo/pull/1',
         prNumber: 1,
@@ -27,7 +27,7 @@ describe('generatePRListString', () => {
     )
 
     const expectedPrListString =
-      '- PR title 1 (<https://your-jira-instance.com/ABC-123|ABC-123>) by @contributor1 in <https://github.com/owner/repo/pull/1|#1>  \n' +
+      '- PR title 1 (<https://your-jira-instance.com/ABC-123|ABC-123>) by @people.one in <https://github.com/owner/repo/pull/1|#1>  \n' +
       '- PR title 2 <https://your-jira-instance.com/ABC-456|ABC-456> by @contributor2 in <https://github.com/owner/repo/pull/2|#2>  \n'
 
     expect(prListString).toEqual(expectedPrListString)
@@ -51,11 +51,15 @@ describe('generatePRListString', () => {
 
     const jiraTicketPrefix = 'ABC'
     const jiraInstanceUrl = 'https://your-jira-instance.com/'
+    const contributorReplaceChar = '.'
+    const contributorReplaceRegex = '-'
 
     const prListString = generatePRListString(
       contributorsCommits,
       jiraTicketPrefix,
-      jiraInstanceUrl
+      jiraInstanceUrl,
+      contributorReplaceChar,
+      contributorReplaceRegex
     )
 
     const expectedPrListString =
@@ -68,31 +72,35 @@ describe('generatePRListString', () => {
   it('should handle PR list with JIRA ticket references without prefix', () => {
     const contributorsCommits = [
       {
-        contributor: 'contributor1',
-        prTitle: 'PR title (123)',
+        contributor: 'people--one',
+        prTitle: 'PR title (ABC-123)',
         prUrl: 'https://github.com/owner/repo/pull/5',
         prNumber: 5,
       },
       {
         contributor: 'contributor2',
-        prTitle: 'Another PR 789',
+        prTitle: 'Another PR ABC-789',
         prUrl: 'https://github.com/owner/repo/pull/6',
         prNumber: 6,
       },
     ]
 
-    const jiraTicketPrefix = 'ABC'
+    const jiraTicketPrefix = ''
     const jiraInstanceUrl = 'https://your-jira-instance.com/'
+    const contributorReplaceChar = '.'
+    const contributorReplaceRegex = '--'
 
     const prListString = generatePRListString(
       contributorsCommits,
       jiraTicketPrefix,
-      jiraInstanceUrl
+      jiraInstanceUrl,
+      contributorReplaceChar,
+      contributorReplaceRegex
     )
 
     const expectedPrListString =
-      '- PR title (123) by @contributor1 in <https://github.com/owner/repo/pull/5|#5>  \n' +
-      '- Another PR 789 by @contributor2 in <https://github.com/owner/repo/pull/6|#6>  \n'
+      '- PR title (ABC-123) by @people.one in <https://github.com/owner/repo/pull/5|#5>  \n' +
+      '- Another PR ABC-789 by @contributor2 in <https://github.com/owner/repo/pull/6|#6>  \n'
 
     expect(prListString).toEqual(expectedPrListString)
   })
@@ -101,13 +109,13 @@ describe('generatePRListString', () => {
     const contributorsCommits = [
       {
         contributor: 'contributor1',
-        prTitle: 'PR title (123)',
+        prTitle: 'PR title (ABC-123)',
         prUrl: 'https://github.com/owner/repo/pull/5',
         prNumber: 5,
       },
       {
         contributor: 'contributor2',
-        prTitle: 'Another PR 789',
+        prTitle: 'Another PR (ABC-789)',
         prUrl: 'https://github.com/owner/repo/pull/6',
         prNumber: 6,
       },
@@ -119,12 +127,14 @@ describe('generatePRListString', () => {
     const prListString = generatePRListString(
       contributorsCommits,
       jiraTicketPrefix,
-      jiraInstanceUrl
+      jiraInstanceUrl,
+      '-',
+      undefined
     )
 
     const expectedPrListString =
-      '- PR title (123) by @contributor1 in <https://github.com/owner/repo/pull/5|#5>  \n' +
-      '- Another PR 789 by @contributor2 in <https://github.com/owner/repo/pull/6|#6>  \n'
+      '- PR title (ABC-123) by @contributor1 in <https://github.com/owner/repo/pull/5|#5>  \n' +
+      '- Another PR (ABC-789) by @contributor2 in <https://github.com/owner/repo/pull/6|#6>  \n'
 
     expect(prListString).toEqual(expectedPrListString)
   })

--- a/src/utils/__tests__/getInputs.test.ts
+++ b/src/utils/__tests__/getInputs.test.ts
@@ -20,6 +20,10 @@ describe('getInputs', () => {
           return 'invalid-jira-ticket-link' // Note: this is not a valid URL
         case 'jira_ticket_prefix':
           return 'ABC' // Note: this is a valid prefix
+        case 'contributor_replace_char':
+          return '.'
+        case 'contributor_replace_regex':
+          return '-'
         default:
           return ''
       }
@@ -36,6 +40,8 @@ describe('getInputs', () => {
       slackWebhookUrl: 'invalid-webhook-url',
       jiraInstanceUrl: 'invalid-jira-ticket-link',
       jiraTicketPrefix: 'ABC',
+      contributorReplaceChar: '.',
+      contributorReplaceRegex: '-',
     }
 
     expect(getInputs()).toEqual(expectedInputs)
@@ -81,6 +87,10 @@ describe('getInputs', () => {
           return 'https://example.atlassian.net/browse' // Note: this is a valid URL
         case 'jira_ticket_prefix':
           return 'ABC' // Note: this is a valid prefix
+        case 'contributor_replace_char':
+          return '.'
+        case 'contributor_replace_regex':
+          return '-'
         default:
           return ''
       }
@@ -97,6 +107,8 @@ describe('getInputs', () => {
       slackWebhookUrl: 'https://hooks.slack.com/services/XXXX/XXXX/XXXX',
       jiraInstanceUrl: 'https://example.atlassian.net/browse',
       jiraTicketPrefix: 'ABC',
+      contributorReplaceChar: '.',
+      contributorReplaceRegex: '-',
     }
 
     expect(getInputs()).toEqual(expectedInputs)
@@ -107,6 +119,8 @@ describe('getInputs', () => {
     expect(core.getInput).toHaveBeenCalledWith('slack_webhook_url')
     expect(core.getInput).toHaveBeenCalledWith('jira_instance_url')
     expect(core.getInput).toHaveBeenCalledWith('jira_ticket_prefix')
+    expect(core.getInput).toHaveBeenCalledWith('contributor_replace_char')
+    expect(core.getInput).toHaveBeenCalledWith('contributor_replace_regex')
     expect(mockWarning).not.toHaveBeenCalled() // no warnings should be logged
 
     mockGetInput.mockRestore()

--- a/src/utils/__tests__/replaceContributorName.test.ts
+++ b/src/utils/__tests__/replaceContributorName.test.ts
@@ -1,0 +1,63 @@
+import { replaceContributorName } from '../replaceContributorName'
+
+describe('replaceContributorName', () => {
+  it('should replace dashes with dots in the contributor name', () => {
+    const contributor = 'people-one'
+    const contributorReplaceChar = '.'
+    const contributorReplaceRegex = '-'
+
+    const updatedContributor = replaceContributorName(
+      contributor,
+      contributorReplaceChar,
+      contributorReplaceRegex
+    )
+
+    const expectedContributor = 'people.one'
+    expect(updatedContributor).toEqual(expectedContributor)
+  })
+
+  it('should replace using the provided regex pattern in the contributor name', () => {
+    const contributor = 'people!one'
+    const contributorReplaceChar = '-'
+    const contributorReplaceRegex = '!'
+
+    const updatedContributor = replaceContributorName(
+      contributor,
+      contributorReplaceChar,
+      contributorReplaceRegex
+    )
+
+    const expectedContributor = 'people-one'
+    expect(updatedContributor).toEqual(expectedContributor)
+  })
+
+  it('should only replace dashes in the contributor name if regex pattern is not provided', () => {
+    const contributor = 'people-one'
+    const contributorReplaceChar = '.'
+    const contributorReplaceRegex = ''
+
+    const updatedContributor = replaceContributorName(
+      contributor,
+      contributorReplaceChar,
+      contributorReplaceRegex
+    )
+
+    const expectedContributor = 'people.one'
+    expect(updatedContributor).toEqual(expectedContributor)
+  })
+
+  it('should not replace any characters if neither replace char nor regex pattern is provided', () => {
+    const contributor = 'people-one'
+    const contributorReplaceChar = ''
+    const contributorReplaceRegex = ''
+
+    const updatedContributor = replaceContributorName(
+      contributor,
+      contributorReplaceChar,
+      contributorReplaceRegex
+    )
+
+    const expectedContributor = 'people-one'
+    expect(updatedContributor).toEqual(expectedContributor)
+  })
+})

--- a/src/utils/__tests__/replaceJiraTicketLinks.test.ts
+++ b/src/utils/__tests__/replaceJiraTicketLinks.test.ts
@@ -1,0 +1,61 @@
+import { replaceJiraTicketLinks } from '../replaceJiraTicketLinks'
+
+describe('replaceJiraTicketLinks', () => {
+  it('should replace JIRA ticket numbers with links in the PR title', () => {
+    const prTitle = 'Fixing bug ABC-123 and adding feature ABC-456'
+    const jiraTicketPrefix = 'ABC'
+    const jiraInstanceUrl = 'https://your-jira-instance.com/'
+
+    const updatedTitle = replaceJiraTicketLinks(
+      prTitle,
+      jiraTicketPrefix,
+      jiraInstanceUrl
+    )
+
+    const expectedTitle =
+      'Fixing bug <https://your-jira-instance.com/ABC-123|ABC-123> and adding feature <https://your-jira-instance.com/ABC-456|ABC-456>'
+    expect(updatedTitle).toEqual(expectedTitle)
+  })
+
+  it('should handle PR title without JIRA ticket references', () => {
+    const prTitle = 'This is a regular PR title without any JIRA ticket references'
+    const jiraTicketPrefix = 'ABC'
+    const jiraInstanceUrl = 'https://your-jira-instance.com/'
+
+    const updatedTitle = replaceJiraTicketLinks(
+      prTitle,
+      jiraTicketPrefix,
+      jiraInstanceUrl
+    )
+
+    expect(updatedTitle).toEqual(prTitle)
+  })
+
+  it('should handle PR title with JIRA ticket references without jiraInstanceUrl', () => {
+    const prTitle = 'Fixing bug ABC-123 and adding feature ABC-456'
+    const jiraTicketPrefix = 'ABC'
+    const jiraInstanceUrl = '' // Empty string for jiraInstanceUrl
+
+    const updatedTitle = replaceJiraTicketLinks(
+      prTitle,
+      jiraTicketPrefix,
+      jiraInstanceUrl
+    )
+
+    expect(updatedTitle).toEqual(prTitle)
+  })
+
+  it('should handle missing jiraTicketPrefix', () => {
+    const prTitle = 'Fixing bug ABC-123 and adding feature ABC-456'
+    const jiraTicketPrefix = ''
+    const jiraInstanceUrl = 'https://your-jira-instance.com/'
+
+    const updatedTitle = replaceJiraTicketLinks(
+      prTitle,
+      jiraTicketPrefix,
+      jiraInstanceUrl
+    )
+
+    expect(updatedTitle).toEqual(prTitle)
+  })
+})

--- a/src/utils/getInputs.ts
+++ b/src/utils/getInputs.ts
@@ -27,6 +27,8 @@ export interface GetInputsType {
   slackWebhookUrl: string
   jiraTicketPrefix: string
   jiraInstanceUrl: string
+  contributorReplaceChar: string
+  contributorReplaceRegex: string
 }
 
 /**
@@ -44,6 +46,8 @@ export function getInputs(): GetInputsType {
   const sentryProjectName = core.getInput('sentry_project_name') || ''
   const sentryProjectId = core.getInput('sentry_project_id') || ''
   const slackWebhookUrl = core.getInput('slack_webhook_url') || ''
+  const contributorReplaceChar = core.getInput('contributor_replace_char') || '.'
+  const contributorReplaceRegex = core.getInput('contributor_replace_regex') || '-'
 
   // Input value checking example for URLs
   if (grafanaDashboardLink && !isValidUrl(grafanaDashboardLink)) {
@@ -93,5 +97,7 @@ export function getInputs(): GetInputsType {
     slackWebhookUrl,
     jiraTicketPrefix,
     jiraInstanceUrl,
+    contributorReplaceChar,
+    contributorReplaceRegex,
   }
 }

--- a/src/utils/replaceContributorName.ts
+++ b/src/utils/replaceContributorName.ts
@@ -1,0 +1,24 @@
+/**
+ * Replace characters in the contributor name.
+ *
+ * @param {string} contributor - The contributor name.
+ * @param {string} contributorReplaceChar - The character to replace in the contributor name.
+ * @param {string} contributorReplaceRegex - The regex pattern to identify characters to be replaced in the contributor name.
+ * @returns {string} The updated contributor name.
+ */
+export function replaceContributorName(
+  contributor: string,
+  contributorReplaceChar: string,
+  contributorReplaceRegex: string
+): string {
+  if (contributorReplaceChar && contributorReplaceRegex) {
+    return contributor.replace(
+      new RegExp(contributorReplaceRegex, 'g'),
+      contributorReplaceChar
+    )
+  } else if (contributorReplaceChar) {
+    return contributor.replace(/-/g, contributorReplaceChar)
+  } else {
+    return contributor
+  }
+}

--- a/src/utils/replaceJiraTicketLinks.ts
+++ b/src/utils/replaceJiraTicketLinks.ts
@@ -1,0 +1,37 @@
+/**
+ * Replace JIRA ticket numbers in the PR title with JIRA ticket links.
+ *
+ * @param {string} prTitle - The pull request title.
+ * @param {string} jiraTicketPrefix - The prefix for JIRA ticket, e.g., 'ABC'.
+ * @param {string} jiraInstanceUrl - The URL for the JIRA instance, e.g., 'https://your-jira-instance.com/browse'.
+ * @returns {string} The PR title with JIRA ticket links.
+ */
+export function replaceJiraTicketLinks(
+  prTitle: string,
+  jiraTicketPrefix: string,
+  jiraInstanceUrl: string
+): string {
+  const jiraTicketPattern = new RegExp(
+    `${jiraTicketPrefix}-\\d+|${jiraTicketPrefix}\\d+`,
+    'g'
+  )
+  const ticketNumbers = prTitle.match(jiraTicketPattern) || []
+
+  let prTitleWithTicketLink = prTitle
+
+  if (jiraInstanceUrl && jiraTicketPrefix) {
+    ticketNumbers.forEach((ticketNumber) => {
+      // Normalize the ticket number to have the format 'ABC-123'
+      const normalizedTicketNumber = ticketNumber.includes('-')
+        ? ticketNumber
+        : `${jiraTicketPrefix}-${ticketNumber}`
+      const jiraTicketLink = `${jiraInstanceUrl}${normalizedTicketNumber}`
+      prTitleWithTicketLink = prTitleWithTicketLink.replace(
+        ticketNumber,
+        `<${jiraTicketLink}|${normalizedTicketNumber}>`
+      )
+    })
+  }
+
+  return prTitleWithTicketLink
+}


### PR DESCRIPTION
This is a new feature that adds some freedom to match the contributor name from Github to the name on Slack.

This is one use-case, more will be added to add more flexibility.

Two new inputs were created:
- `contributor_replace_regex` which indicates the character to target
- `contributor_replace_char` which should be the character that will replace "contributor_replace_regex"

Both have a default value