### PR TITLE
fix: missing tagRegex mock test data

### DIFF
--- a/src/utils/__tests__/__mocks__/testData.ts
+++ b/src/utils/__tests__/__mocks__/testData.ts
@@ -63,4 +63,5 @@ export const MOCK_GET_INPUTS = {
   jiraInstanceUrl: 'https://jira.myProject.com',
   contributorReplaceChar: '.',
   contributorReplaceRegex: '-',
+  tagRegex: '^v[0-9]+\\.[0-9]+\\.[0-9]+$',
 }


### PR DESCRIPTION
## Description

Add missing `tagRegex` key and value in mock testData.